### PR TITLE
Remove retry when schedule data can't be fetched

### DIFF
--- a/web/src/app/services/data/data.service.ts
+++ b/web/src/app/services/data/data.service.ts
@@ -161,10 +161,7 @@ export class DataService {
         console.log("Schedule updated");
       },
       err => {
-        setTimeout(() => {
-          console.error("failed to get schedule data", err);
-          this.getScheduleData();
-        }, 5000);
+		console.error("failed to get schedule data", err);
       }
     );
   };


### PR DESCRIPTION
The service checks for schedule data every 30 seconds. This loop is
not affected by the fact that a previous attempt to get schedule data
may still be in a retry loop. This causes us to add more and more
threads making requests every 5 seconds in an extended outage which
eventually leads to crashing chrome.

This change remove the retry loop and instead favors the fact that the
parent loop will fetch events again in 30 seconds anyways, so we can
just ignore an error.